### PR TITLE
upgrade compatible

### DIFF
--- a/src/sql/resolver/ddl/ob_create_table_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_create_table_resolver.cpp
@@ -2384,6 +2384,18 @@ int ObCreateTableResolver::set_table_option_to_schema(ObTableSchema &table_schem
       }
     }
 
+    if (OB_SUCC(ret) && table_schema.get_compressor_type() == ObCompressorType::ZLIB_LITE_COMPRESSOR) {
+      uint64_t tenant_data_version = 0;
+      if (OB_FAIL(GET_MIN_DATA_VERSION(session_info_->get_effective_tenant_id(), tenant_data_version))) {
+        LOG_WARN("get tenant data version failed", K(ret));
+      } else if (tenant_data_version < DATA_VERSION_4_2_0_0) {
+        ret = OB_NOT_SUPPORTED;
+        LOG_WARN("tenant version is less than 4.2, zlib_lite compress method is not supported",
+                 K(ret), K(tenant_data_version));
+        LOG_USER_ERROR(OB_NOT_SUPPORTED, "version is less than 4.2, zlib_lite");
+      }
+    }
+
     if (OB_SUCC(ret) && table_schema.is_external_table()) {
       if (table_schema.get_external_file_format().empty()
           || table_schema.get_external_file_location().empty()) {


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

We should disable zlib_lite while upgrading the cluster.

### Solution Description

<!-- Please clearly and consice descipt the solution. -->

I throw an use error if use zlib_lite when creating table in upgrading progress.

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
